### PR TITLE
feat: make local proxy host address configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,12 @@
           "scope": "application",
           "description": "Use local proxy via SSH tunnel. If true, the extension will manage ~/.ssh/config.antigravity and forward the remote port to your local machine."
         },
+        "antigravity-ssh-proxy.localProxyHost": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "scope": "application",
+          "description": "Local proxy host address on your computer. Only used when enableLocalForwarding is true. Change from 127.0.0.1 if your proxy listens on a different address."
+        },
         "antigravity-ssh-proxy.localProxyPort": {
           "type": "number",
           "default": 7890,

--- a/src/diagnostics/diagnosticRunner.ts
+++ b/src/diagnostics/diagnosticRunner.ts
@@ -63,7 +63,7 @@ function getSSHConfigPath(): string {
 /**
  * Check local proxy service
  */
-async function checkLocalProxy(localProxyPort: number): Promise<DiagnosticCheck> {
+async function checkLocalProxy(localProxyPort: number, localProxyHost: string = '127.0.0.1'): Promise<DiagnosticCheck> {
     const check: DiagnosticCheck = {
         id: 'local-proxy',
         name: 'Local Proxy Service',
@@ -71,13 +71,13 @@ async function checkLocalProxy(localProxyPort: number): Promise<DiagnosticCheck>
     };
 
     try {
-        const reachable = await checkPort('127.0.0.1', localProxyPort);
+        const reachable = await checkPort(localProxyHost, localProxyPort);
         if (reachable) {
             check.status = 'success';
-            check.message = `Local proxy is running on port ${localProxyPort}`;
+            check.message = `Local proxy is running on ${localProxyHost}:${localProxyPort}`;
         } else {
             check.status = 'error';
-            check.message = `Cannot connect to local proxy on port ${localProxyPort}`;
+            check.message = `Cannot connect to local proxy on ${localProxyHost}:${localProxyPort}`;
             check.suggestion = 'Please ensure your local proxy (e.g., Clash, V2Ray) is running and listening on the configured port.';
         }
     } catch (error) {
@@ -502,6 +502,7 @@ async function checkExternalConnectivity(remoteProxyHost: string, remoteProxyPor
 export async function runDiagnostics(onProgress?: ProgressCallback, extensionPath?: string): Promise<DiagnosticReport> {
     const config = vscode.workspace.getConfiguration('antigravity-ssh-proxy');
     const localProxyPort = config.get<number>('localProxyPort', 7890);
+    const localProxyHost = config.get<string>('localProxyHost', '127.0.0.1');
     const remoteProxyPort = config.get<number>('remoteProxyPort', 7890);
     const remoteProxyHost = config.get<string>('remoteProxyHost', '127.0.0.1');
     const proxyType = config.get<string>('proxyType', 'http');
@@ -528,7 +529,7 @@ export async function runDiagnostics(onProgress?: ProgressCallback, extensionPat
         // Local environment: check steps 1-2
         checks[0].status = 'running';
         onProgress?.(checks);
-        updateCheck(0, await checkLocalProxy(localProxyPort));
+        updateCheck(0, await checkLocalProxy(localProxyPort, localProxyHost));
 
         checks[1].status = 'running';
         onProgress?.(checks);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,7 @@ function getAntigravityConfigPath(): string {
 /**
  * Update the SSH config files using the Include approach
  */
-async function updateSSHConfigFile(remotePort: number, localPort: number, enable: boolean): Promise<void> {
+async function updateSSHConfigFile(remotePort: number, localPort: number, enable: boolean, localHost: string = '127.0.0.1'): Promise<void> {
 	const mainConfigPath = getSSHConfigPath();
 	const antiConfigPath = getAntigravityConfigPath();
 
@@ -188,7 +188,7 @@ async function updateSSHConfigFile(remotePort: number, localPort: number, enable
 				'# Antigravity SSH Proxy Configuration',
 				`# Generated at: ${new Date().toISOString()}`,
 				'Match all',
-				`    RemoteForward ${remotePort} 127.0.0.1:${localPort}`,
+				`    RemoteForward ${remotePort} ${localHost}:${localPort}`,
 				'    ExitOnForwardFailure no',
 				'    VisualHostKey no',
 				'',
@@ -243,7 +243,7 @@ async function getSSHConfigStatus(): Promise<{ enabled: boolean; port?: number }
 		const mainContent = await fs.readFile(getSSHConfigPath(), 'utf-8');
 		if (mainContent.includes(INCLUDE_LINE)) {
 			const antiContent = await fs.readFile(getAntigravityConfigPath(), 'utf-8');
-			const match = antiContent.match(/RemoteForward\s+(\d+)\s+(?:localhost|127\.0\.0\.1):/);
+			const match = antiContent.match(/RemoteForward\s+(\d+)\s+[^\s:]+:\d+/);
 			if (match) {
 				return { enabled: true, port: parseInt(match[1]) };
 			}
@@ -322,27 +322,29 @@ async function activateLocal(context: vscode.ExtensionContext) {
 	// 设置配置变更回调（用于面板中修改配置时触发）
 	statusManager.setConfigChangeCallback(async () => {
 		const cfg = vscode.workspace.getConfiguration('antigravity-ssh-proxy');
+		const lh = cfg.get<string>('localProxyHost', '127.0.0.1');
 		const lp = cfg.get<number>('localProxyPort', 7890);
 		const rp = cfg.get<number>('remoteProxyPort', 7890);
 		const enabled = cfg.get<boolean>('enableLocalForwarding', true);
-		await updateSSHConfigFile(rp, lp, enabled);
+		await updateSSHConfigFile(rp, lp, enabled, lh);
 		statusManager.updateSSHConfigStatus(enabled, rp);
 	});
 
 	const config = vscode.workspace.getConfiguration('antigravity-ssh-proxy');
 	const enable = config.get<boolean>('enableLocalForwarding', true);
+	const localHost = config.get<string>('localProxyHost', '127.0.0.1');
 	const localPort = config.get<number>('localProxyPort', 7890);
 	const remotePort = config.get<number>('remoteProxyPort', 7890);
 
-	log(`Config: enable=${enable}, localPort=${localPort}, remotePort=${remotePort}`);
+	log(`Config: enable=${enable}, localHost=${localHost}, localPort=${localPort}, remotePort=${remotePort}`);
 
 	// Auto-setup on activation
 	if (enable) {
-		await updateSSHConfigFile(remotePort, localPort, true);
+		await updateSSHConfigFile(remotePort, localPort, true, localHost);
 		statusManager.updateSSHConfigStatus(true, remotePort);
-		if (!await checkPortAvailable('127.0.0.1', localPort)) {
+		if (!await checkPortAvailable(localHost, localPort)) {
 			vscode.window.showWarningMessage(
-				`Local proxy at 127.0.0.1:${localPort} is not running. ` +
+				`Local proxy at ${localHost}:${localPort} is not running. ` +
 				`Also check if port ${remotePort} is occupied on the remote server before reconnecting.`
 			);
 		}
@@ -360,10 +362,11 @@ async function activateLocal(context: vscode.ExtensionContext) {
 		vscode.workspace.onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
 			if (e.affectsConfiguration('antigravity-ssh-proxy')) {
 				const cfg = vscode.workspace.getConfiguration('antigravity-ssh-proxy');
+				const lh = cfg.get<string>('localProxyHost', '127.0.0.1');
 				const lp = cfg.get<number>('localProxyPort', 7890);
 				const rp = cfg.get<number>('remoteProxyPort', 7890);
 				const enabled = cfg.get<boolean>('enableLocalForwarding', true);
-				await updateSSHConfigFile(rp, lp, enabled);
+				await updateSSHConfigFile(rp, lp, enabled, lh);
 				statusManager.updateSSHConfigStatus(enabled, rp);
 				await statusManager.refreshStatus();
 			}
@@ -374,9 +377,10 @@ async function activateLocal(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('antigravity-ssh-proxy.enableForwarding', async () => {
 			const cfg = vscode.workspace.getConfiguration('antigravity-ssh-proxy');
+			const lh = cfg.get<string>('localProxyHost', '127.0.0.1');
 			const lp = cfg.get<number>('localProxyPort', 7890);
 			const rp = cfg.get<number>('remoteProxyPort', 7890);
-			await updateSSHConfigFile(rp, lp, true);
+			await updateSSHConfigFile(rp, lp, true, lh);
 			statusManager.updateSSHConfigStatus(true, rp);
 			await statusManager.refreshStatus();
 			vscode.window.showInformationMessage('SSH port forwarding enabled');

--- a/src/statusManager.ts
+++ b/src/statusManager.ts
@@ -284,7 +284,7 @@ export class StatusManager {
 
         if (this.isLocal) {
             this.currentStatus.localProxyReachable = await this.checkPort(
-                '127.0.0.1',
+                config.get<string>('localProxyHost', '127.0.0.1'),
                 this.currentStatus.localProxyPort
             );
         } else {


### PR DESCRIPTION
This pull request adds support for customizing the local proxy host address in the Antigravity SSH Proxy extension. Previously, the local proxy host was hardcoded to `127.0.0.1`; now, users can configure this value, allowing the extension to work with proxies listening on different addresses. The changes update configuration, diagnostics, SSH config generation, and status management to use the new option.

Configuration enhancements:

* Added the `antigravity-ssh-proxy.localProxyHost` setting to `package.json`, allowing users to specify the local proxy host address.

Diagnostics and status improvements:

* Updated `checkLocalProxy` and `runDiagnostics` in `src/diagnostics/diagnosticRunner.ts` to use the configurable local proxy host instead of a hardcoded address. [[1]](diffhunk://#diff-f97813b3beb519b0fe937bc1bcbe9a8d65aeef65d6efbbf4ff49d114f945b9e7L66-R80) [[2]](diffhunk://#diff-f97813b3beb519b0fe937bc1bcbe9a8d65aeef65d6efbbf4ff49d114f945b9e7R505) [[3]](diffhunk://#diff-f97813b3beb519b0fe937bc1bcbe9a8d65aeef65d6efbbf4ff49d114f945b9e7L531-R532)
* Modified `StatusManager` in `src/statusManager.ts` to check the local proxy on the configured host address.

SSH config generation and management:

* Updated `updateSSHConfigFile` and related calls in `src/extension.ts` to use the configurable local proxy host, ensuring SSH forwarding works with the specified address. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L177-R177) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L191-R191) [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R325-R347) [[4]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R365-R369) [[5]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R380-R383)
* Improved SSH config status detection to match any host address, not just `localhost` or `127.0.0.1`.