### PR TITLE
fix: support both .antigravity-ide-server and .antigravity-server directories

### DIFF
--- a/scripts/setup-proxy.sh
+++ b/scripts/setup-proxy.sh
@@ -85,12 +85,41 @@ debug_log "Expected Binary: $EXPECTED_BINARY"
 debug_log "Expected Library: $EXPECTED_LIB"
 
 # ============================================================================
+# Server Directory Discovery
+# ============================================================================
+# Antigravity IDE has used different directory names across versions:
+#   - .antigravity-ide-server (new, 2.x+)
+#   - .antigravity-server (legacy)
+# We search for the actual directory in priority order.
+# ============================================================================
+POSSIBLE_SERVER_DIRS=(
+    "$HOME/.antigravity-ide-server"
+    "$HOME/.antigravity-server"
+)
+
+SERVER_DIR=""
+for dir in "${POSSIBLE_SERVER_DIRS[@]}"; do
+    if [ -d "$dir/bin" ]; then
+        SERVER_DIR="$dir"
+        break
+    fi
+done
+
+if [ -z "$SERVER_DIR" ]; then
+    error_log "No Antigravity server directory found!"
+    error_log "Searched: ${POSSIBLE_SERVER_DIRS[*]}"
+    exit 1
+fi
+
+info_log "Server Directory: $SERVER_DIR"
+
+# ============================================================================
 # Scan for extension directories (for debugging)
 # ============================================================================
 if [ "$DEBUG" = "1" ]; then
     echo ""
     echo "[SCAN] Searching for extension directories..."
-    EXT_DIRS=$(ls -d "$HOME/.antigravity-server/extensions/"*antigravity-ssh-proxy* 2>/dev/null | sort -t'-' -k3 -V -r || echo "")
+    EXT_DIRS=$(ls -d "$SERVER_DIR/extensions/"*antigravity-ssh-proxy* 2>/dev/null | sort -t'-' -k3 -V -r || echo "")
     if [ -n "$EXT_DIRS" ]; then
         echo "$EXT_DIRS" | while read -r dir; do
             echo "  📦 $dir"
@@ -181,7 +210,7 @@ check_needs_update() {
 # Find Language Servers
 # ============================================================================
 echo "[SEARCH] Looking for language servers..."
-TARGETS=$(find "$HOME/.antigravity-server/bin" -path "*/extensions/antigravity/bin/language_server_linux_*" -type f 2>/dev/null | grep -v ".bak$")
+TARGETS=$(find "$SERVER_DIR/bin" -path "*/extensions/antigravity/bin/language_server_linux_*" -type f 2>/dev/null | grep -v ".bak$")
 
 if [ -z "$TARGETS" ]; then
     error_log "No language servers found!"
@@ -291,7 +320,8 @@ find_binaries() {
     fi
     
     # Method 2: Fallback - search in all versions (sorted by version, newest first)
-    for dir in $(ls -d "$HOME/.antigravity-server/extensions/"*antigravity-ssh-proxy*/resources/bin 2>/dev/null | sort -t'-' -k3 -V -r); do
+    # Search in all possible server directories (new name first, then legacy)
+    for dir in $(ls -d "$HOME/.antigravity-ide-server/extensions/"*antigravity-ssh-proxy*/resources/bin "$HOME/.antigravity-server/extensions/"*antigravity-ssh-proxy*/resources/bin 2>/dev/null | sort -t'-' -k3 -V -r); do
         if [ -f "$dir/$binary_name" ]; then
             echo "$dir/$binary_name"
             if [ -f "$dir/$lib_name" ]; then

--- a/src/diagnostics/diagnosticRunner.ts
+++ b/src/diagnostics/diagnosticRunner.ts
@@ -8,6 +8,12 @@ import { promisify } from 'util';
 
 const execAsync = promisify(exec);
 
+/**
+ * Possible Antigravity server directory names, in priority order.
+ * IDE renamed from .antigravity-server to .antigravity-ide-server in 2.x+.
+ */
+const SERVER_DIR_NAMES = ['.antigravity-ide-server', '.antigravity-server'];
+
 export interface DiagnosticCheck {
     id: string;
     name: string;
@@ -221,15 +227,20 @@ async function checkMgraftcp(extensionPath?: string): Promise<DiagnosticCheck> {
             }
         }
         
-        // Method 2: Fallback - search in all versions (sorted by version, newest first)
+        // Method 2: Fallback - search in all possible server dirs and versions
         if (!binaryPath) {
-            const searchPattern = `${homeDir}/.antigravity-server/extensions/*antigravity-ssh-proxy*/resources/bin/${binaryName}`;
-            const { stdout } = await execAsync(`ls ${searchPattern} 2>/dev/null | sort -V -r | head -1`);
-            binaryPath = stdout.trim();
-            
-            if (binaryPath) {
-                // Check if executable
-                await fs.access(binaryPath, fs.constants.X_OK);
+            for (const dirName of SERVER_DIR_NAMES) {
+                const searchPattern = `${homeDir}/${dirName}/extensions/*antigravity-ssh-proxy*/resources/bin/${binaryName}`;
+                try {
+                    const { stdout } = await execAsync(`ls ${searchPattern} 2>/dev/null | sort -V -r | head -1`);
+                    binaryPath = stdout.trim();
+                    if (binaryPath) {
+                        await fs.access(binaryPath, fs.constants.X_OK);
+                        break;
+                    }
+                } catch {
+                    binaryPath = '';
+                }
             }
         }
 
@@ -283,10 +294,19 @@ async function checkLanguageServerWrapper(extensionPath?: string): Promise<Diagn
             return check;
         }
         
-        const { stdout } = await execAsync(
-            `find "$HOME/.antigravity-server/bin" -path "*/extensions/antigravity/bin/language_server_linux_*" -type f 2>/dev/null | grep -v ".bak$" | head -1`
-        );
-        const targetPath = stdout.trim();
+        // Search in all possible server directories
+        let targetPath = '';
+        for (const dirName of SERVER_DIR_NAMES) {
+            try {
+                const { stdout } = await execAsync(
+                    `find "$HOME/${dirName}/bin" -path "*/extensions/antigravity/bin/language_server_linux_*" -type f 2>/dev/null | grep -v ".bak$" | head -1`
+                );
+                targetPath = stdout.trim();
+                if (targetPath) { break; }
+            } catch {
+                // continue to next directory
+            }
+        }
 
         if (!targetPath) {
             check.status = 'warning';

--- a/src/remoteSetup.ts
+++ b/src/remoteSetup.ts
@@ -16,8 +16,15 @@ export function generateRollbackScript(): string {
     return `#!/bin/bash
 set -e
 
-# Find all backup files and restore them
-BAKS=$(find "$HOME/.antigravity-server" -path "*/extensions/antigravity/bin/*" -name "language_server_linux_*.bak" -type f 2>/dev/null)
+# Search in all possible server directories (new name first, then legacy)
+BAKS=""
+for DIR in "$HOME/.antigravity-ide-server" "$HOME/.antigravity-server"; do
+    FOUND=$(find "$DIR" -path "*/extensions/antigravity/bin/*" -name "language_server_linux_*.bak" -type f 2>/dev/null)
+    [ -n "$FOUND" ] && BAKS="$BAKS
+$FOUND"
+done
+BAKS=$(echo "$BAKS" | sed '/^$/d')
+
 [ -z "$BAKS" ] && echo "Nothing to rollback" && exit 0
 
 RESTORED=0


### PR DESCRIPTION
Antigravity IDE renamed its installation directory from ~/.antigravity-server to ~/.antigravity-ide-server in 2.x+. This broke all hardcoded paths, preventing wrapper creation and causing Language Server to run without proxy.

Changes:
- setup-proxy.sh: Add server directory discovery logic that checks .antigravity-ide-server first, then .antigravity-server. Fix 3 hardcoded paths (debug scan, LS search, wrapper fallback).
- diagnosticRunner.ts: Add SERVER_DIR_NAMES constant and fix 2 fallback search paths in checkMgraftcp() and checkLanguageServerWrapper().
- remoteSetup.ts: Fix rollback script to search both directories.

Fixes: LS timeout due to missing proxy wrapper on renamed dirs.